### PR TITLE
Improve descrambling and fix some rendering

### DIFF
--- a/src/ireal-reader-tiny.js
+++ b/src/ireal-reader-tiny.js
@@ -62,10 +62,7 @@ class Song {
 		}
 		r = r + s;
 		// now undo substitution obfuscation
-		//r =  r.replace('/Kcl/g', '| x').replace('/LZ/g', ' |').replace('/XyQ/g', '   ');
-		r =  r.replace(/Kcl/g, '| x');
-		r =  r.replace(/LZ/g, ' |');
-		r =  r.replace(/XyQ/g, '   ');
+		r =  r.replace(/Kcl/g, '| x').replace(/LZ/g, ' |').replace(/XyQ/g, '   ');
 		return r;
 	}
 

--- a/src/ireal-reader-tiny.js
+++ b/src/ireal-reader-tiny.js
@@ -50,19 +50,22 @@ class Song {
 
 	//unscrambling hints from https://github.com/ironss/accompaniser/blob/master/irealb_parser.lua
 	//strings are broken up in 50 character segments. each segment undergoes character substitution addressed by obfusc50()
+	//note that a final part of length 50 or 51 is not scrambled.
+	//finally need to substitute for Kcl, LZ and XyQ.
 	unscramble(s) {
 		let r = '', p;
 
-		while(s.length > 50){
+		while(s.length > 51){
 			p = s.substring(0, 50);
 			s = s.substring(50);
-			if(s.length < 2){
-				r = r + p;
-			}else{
-				r = r + this.obfusc50(p);
-			}
+			r = r + this.obfusc50(p);
 		}
 		r = r + s;
+		// now undo substitution obfuscation
+		//r =  r.replace('/Kcl/g', '| x').replace('/LZ/g', ' |').replace('/XyQ/g', '   ');
+		r =  r.replace(/Kcl/g, '| x');
+		r =  r.replace(/LZ/g, ' |');
+		r =  r.replace(/XyQ/g, '   ');
 		return r;
 	}
 

--- a/src/ireal-renderer.js
+++ b/src/ireal-renderer.js
@@ -478,7 +478,7 @@ class iRealRenderer {
  * 5 - the top chord as (chord)
  * @type RegExp
  */
-iRealRenderer.chordRegex = /^([ A-GW][b#]?)((?:sus|[\+\-\^\dhob#])*)(\*.+?\*)*(\/[A-G][#b]?)?(\(.*?\))?/;
+iRealRenderer.chordRegex = /^([ A-GWp][b#]?)((?:sus|alt|[\+\-\^\dhob#])*)(\*.+?\*)*(\/[A-G][#b]?)?(\(.*?\))?/;
 
 iRealRenderer.regExps = [
 	/^\*[a-zA-Z]/,							// section

--- a/src/ireal-renderer.js
+++ b/src/ireal-renderer.js
@@ -69,11 +69,7 @@ class iRealRenderer {
 					found = true;
 					if (match.length <= 2) {
 						match = match[0];
-						var repl = iRealRenderer.replacements[match];
-						if (repl)
-							arr = arr.concat(repl);
-						else
-							arr.push(match);
+						arr.push(match);
 						text = text.substr(match.length);
 					}
 					else {
@@ -123,7 +119,6 @@ class iRealRenderer {
 					break;
 				case '<': 
 					token = token.substr(1, token.length-2);
-					token = token.replace(/XyQ/g, "   ");	// weird; needs to be done
 					obj.comments.push(token); 
 					token = null; break;
 				default:
@@ -149,7 +144,7 @@ class iRealRenderer {
 		var modifiers = match[2] || "";
 		var comment = match[3] || "";
 		if (comment)
-			modifiers += comment.substr(1, comment.length-2).replace("XyQ", "   ");
+			modifiers += comment.substr(1, comment.length-2);
 		var over = match[4] || "";
 		if (over[0] === '/')
 			over = over.substr(1);
@@ -492,16 +487,7 @@ iRealRenderer.regExps = [
 	/^<.*?>/,								// comments
 	/^ \(.*?\)/,							// blank and (note)
 	iRealRenderer.chordRegex,				// chords
-	/^LZ/,									// 1 cell + right bar
-	/^XyQ/,									// 3 empty cells
-	/^Kcl/									// repeat last bar
 ];
-
-iRealRenderer.replacements = {
-	"LZ": [" ", "|"],
-	"XyQ": [" ", " ", " "],
-	"Kcl": ["|", " ", "x"]
-};
 
 iRealRenderer.cssPrefix = "";
 


### PR DESCRIPTION
This PR provides two improvements:

1. Simplifies the unscrambling loop, and also performs the substitutions for `Kcl`, `LZ` and `XyQ` in the reading, rather than the rendering, as they are just part of the scrambling, not the song representation.
2. Adds `alt` and `p` to the chord regex. The `alt` is required by tunes such as _A Child is Born_, which has a `D7alt`, and `p` is used in many tunes to indicate a beat with a `/`