### PR TITLE
Some more rendering fixes

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -32,7 +32,7 @@ window.addEventListener("load", async () => {
 		r.parse(song);
 		song = r.transpose(song, options);
 		var container = document.getElementById("song-" + index);
-		container.innerHTML = `<h3>${song.title} (${song.key})</h3>`;
+		container.innerHTML = `<h3>${song.title} (${song.key.replace(/b/g, "\u266d").replace(/#/g, "\u266f")})</h3>`;
 		r.render(song, container, options);			
 	}
 	

--- a/src/ireal-renderer.js
+++ b/src/ireal-renderer.js
@@ -479,7 +479,7 @@ class iRealRenderer {
  * 5 - the top chord as (chord)
  * @type RegExp
  */
-iRealRenderer.chordRegex = /^([ A-GWp][b#]?)((?:sus|alt|[\+\-\^\dhob#])*)(\*.+?\*)*(\/[A-G][#b]?)?(\(.*?\))?/;
+iRealRenderer.chordRegex = /^([ A-GWp][b#]?)((?:sus|alt|add|[\+\-\^\dhob#])*)(\*.+?\*)*(\/[A-G][#b]?)?(\(.*?\))?/;
 
 iRealRenderer.regExps = [
 	/^\*[a-zA-Z]/,							// section

--- a/src/ireal-renderer.js
+++ b/src/ireal-renderer.js
@@ -165,6 +165,7 @@ class iRealRenderer {
 		}
 		else
 			over = null;
+		modifiers = modifiers.replace(/b/g, "\u266d").replace(/#/g, "\u266f");	// convert to proper flat and sharp
 		return new iRealChord(note, modifiers, over, alternate);
 	}
 	

--- a/src/ireal-renderer.js
+++ b/src/ireal-renderer.js
@@ -312,7 +312,6 @@ class iRealRenderer {
 		  switch(data.chord.note) {
 			case 'x':	// 1-bar repeat
 			case 'r':	// 2-bar repeat
-			case 'p':	// pause
 			case 'n':	// N.C.
 				let cls = iRealRenderer.classes[data.chord.note];
 				html = `<irr-char class="${cls}"></irr-char>`; break;
@@ -357,6 +356,8 @@ class iRealRenderer {
 		var { note, modifiers } = chord;
 		if (note === "W")
 			note = `<irr-char class="irr-root Root"></irr-char>`;
+		if (note === "p")
+			note = `<irr-char class="Repeated-Figure1"></irr-char>`;
 		var sup = "";
 		switch(note[1]) {
 			case 'b': sup = "<sup>\u266d</sup>"; note = note[0]; break;
@@ -485,7 +486,6 @@ iRealRenderer.regExps = [
 	/^T\d\d/,								// time measurement
 	/^N./,									// repeat marker
 	/^<.*?>/,								// comments
-	/^ \(.*?\)/,							// blank and (note)
 	iRealRenderer.chordRegex,				// chords
 ];
 

--- a/src/ireal-renderer.js
+++ b/src/ireal-renderer.js
@@ -318,18 +318,22 @@ class iRealRenderer {
 			default:
 				html = this.chordHtml(data.chord);
 		}
+		let oldc = '';
 		for (var i = 0; i < data.bars.length; i++) {
 			let c = data.bars[i];
-			let cls = iRealRenderer.classes[c];
-			switch(c) {
-				case '|': 
-				case '[':
-				case '{': 
-					html = `<irr-lbar class="${cls}"></irr-lbar>` + html; break;
-				case ']':
-				case '}':
-				case 'Z':
-					html = `<irr-rbar class="${cls}"></irr-rbar>` + html; break;
+			if (c != oldc) {
+				let cls = iRealRenderer.classes[c];
+				switch(c) {
+					case '|':
+					case '[':
+					case '{':
+						html = `<irr-lbar class="${cls}"></irr-lbar>` + html; break;
+					case ']':
+					case '}':
+					case 'Z':
+						html = `<irr-rbar class="${cls}"></irr-rbar>` + html; break;
+				}
+				oldc = c;
 			}
 		}
 		if (!html)

--- a/src/ireal-renderer.js
+++ b/src/ireal-renderer.js
@@ -287,7 +287,7 @@ class iRealRenderer {
 		
 		for (var i = 0; i < song.cells.length; i++) {
 			var cell = song.cells[i];
-			if (this.cell < 0 || this.cell === 15 || cell.spacer)
+			if (this.cell < 0 || this.cell === 15)
 				this.nextRow(table, cell.spacer);
 			else
 				this.cell++;

--- a/src/ireal-renderer.js
+++ b/src/ireal-renderer.js
@@ -484,7 +484,8 @@ class iRealRenderer {
  * 5 - the top chord as (chord)
  * @type RegExp
  */
-iRealRenderer.chordRegex = /^([ A-GWp][b#]?)((?:sus|alt|add|[\+\-\^\dhob#])*)(\*.+?\*)*(\/[A-G][#b]?)?(\(.*?\))?/;
+iRealRenderer.chordRegex = /^([A-G][b#]?)((?:sus|alt|add|[\+\-\^\dhob#])*)(\*.+?\*)*(\/[A-G][#b]?)?(\(.*?\))?/;
+iRealRenderer.chordRegex2 = /^([ Wp])()()(\/[A-G][#b]?)?(\(.*?\))?/;	// need the empty captures to match chordRegex
 
 iRealRenderer.regExps = [
 	/^\*[a-zA-Z]/,							// section
@@ -492,6 +493,7 @@ iRealRenderer.regExps = [
 	/^N./,									// repeat marker
 	/^<.*?>/,								// comments
 	iRealRenderer.chordRegex,				// chords
+	iRealRenderer.chordRegex2,				// space, W and p (with optional alt chord)
 ];
 
 iRealRenderer.cssPrefix = "";


### PR DESCRIPTION
Some fixes for tunes in the Jazz1350 book:

1. Add missing `add` to chord regex.
2. Fix missing alternate chords over `p` and `space`.
3. Temporary fix for repeated barline at start of a line. This needs further work, as a `|` should explicitly put a barline at the end of a line.